### PR TITLE
use a function instead of a macro for jpeg detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,8 @@ AC_SEARCH_LIBS([png_create_read_struct], [png], [
 	]
 )
 
-AC_SEARCH_LIBS([jpeg_create_decompress], [jpeg], [
-	LIBS="-ljpeg"
+AC_SEARCH_LIBS([jpeg_start_decompress], [jpeg], [
+	LIBS="$LIBS -ljpeg"
 	CFLAGS="$CFLAGS -DFBV_SUPPORT_JPEG"
 	], [
 	]


### PR DESCRIPTION
the macro does not work, so use a function.
Tested on a raspberry pi 5.